### PR TITLE
Move randomHEX test file and fix Vitest configuration

### DIFF
--- a/test/front/lib/randomHEX.spec.ts
+++ b/test/front/lib/randomHEX.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import randomHEX from "../src/front/lib/randomHEX";
+import randomHEX from "../../../src/front/lib/randomHEX";
 import crypto from "node:crypto";
 
 describe("randomHEX", () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,10 +11,6 @@ export default defineConfig({
 			wrangler: { configPath: "./wrangler.jsonc" },
 		}),
 	],
-import tsconfigPaths from "vite-tsconfig-paths";
-
-export default defineWorkersConfig({
-	plugins: [tsconfigPaths()],
 
 	test: {
 		testTimeout: 15000,


### PR DESCRIPTION
The user requested to move `test/randomHEX.spec.ts` to `test/front/lib`. I performed the move using `rename_file` and updated the relative import path within the test file using `replace_with_git_merge_diff`. During the verification phase, I discovered a syntax error in `vitest.config.mts` (duplicate imports and nested `export default` calls) that was causing test runs to fail. I corrected the configuration file and successfully verified that all project tests pass.

Fixes #10

---
*PR created automatically by Jules for task [11348037609351754681](https://jules.google.com/task/11348037609351754681) started by @frkr*