### PR TITLE
Add RETRY button to message details popover

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,53 @@
+
+> cfgateway@0.0.1 dev
+> react-router dev
+
+(node:34372) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.
+The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  Debug:   http://localhost:5173/__debug
+DB error: Error: D1_ERROR: no such table: messages: SQLITE_ERROR
+    at D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api:139:19)
+    at cloudflare-internal:d1-api:353:41
+    ... 7 lines matching cause stack trace ...
+    at callDataStrategyImpl (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3164:16) {
+  [cause]: Error: no such table: messages: SQLITE_ERROR
+      at D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api:140:24)
+      at cloudflare-internal:d1-api:353:41
+      at loader (/app/src/front/.server/panel/panel.ts:13:23)
+      at callRouteHandler (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:8447:15)
+      at commonRoute.loader (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:8551:12)
+      at /app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3198:14
+      at callLoaderOrAction (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3242:19)
+      at async Promise.all (index 0)
+      at defaultDataStrategy (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:2999:3)
+      at callDataStrategyImpl (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3164:16)
+}
+3:45:28 AM [vite] (client) hmr update /src/front/routes/panel.tsx
+3:45:28 AM [vite] (ssr) hmr update /src/front/app.css, /@id/virtual:cloudflare/worker-entry
+3:45:28 AM [vite] (client) hmr update /src/front/app.css
+[vite] hot updated: virtual:cloudflare/worker-entry
+DB error: Error: D1_ERROR: no such table: messages: SQLITE_ERROR
+    at D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api:139:19)
+    at cloudflare-internal:d1-api:353:41
+    ... 7 lines matching cause stack trace ...
+    at callDataStrategyImpl (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3164:16) {
+  [cause]: Error: no such table: messages: SQLITE_ERROR
+      at D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api:140:24)
+      at cloudflare-internal:d1-api:353:41
+      at loader (/app/src/front/.server/panel/panel.ts:13:23)
+      at callRouteHandler (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:8447:15)
+      at commonRoute.loader (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:8551:12)
+      at /app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3198:14
+      at callLoaderOrAction (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3242:19)
+      at async Promise.all (index 0)
+      at defaultDataStrategy (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:2999:3)
+      at callDataStrategyImpl (/app/node_modules/.vite/deps_ssr/react-router.js?v=88eb318c:3164:16)
+}
+3:45:47 AM [vite] (client) hmr update /src/front/routes/panel.tsx
+3:45:47 AM [vite] (ssr) hmr update /src/front/app.css, /@id/virtual:cloudflare/worker-entry
+3:45:47 AM [vite] (client) hmr update /src/front/app.css
+[vite] hot updated: virtual:cloudflare/worker-entry

--- a/src/front/.server/panel/panel.ts
+++ b/src/front/.server/panel/panel.ts
@@ -1,6 +1,7 @@
 import type { Route } from "../../routes/+types/panel";
 import database from './database.json';
 import type { Message } from '@/database';
+import type { MQCFGATEWAYMessage } from '@/MQCFGATEWAY';
 
 export async function loader({ request, context }: Route.LoaderArgs) {
 	const accept = request.headers.get("Accept") || "";
@@ -32,4 +33,28 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	}
 }
 
-export const action = loader;
+export async function action({ request, context }: Route.ActionArgs) {
+	if (request.method === "POST") {
+		try {
+			const body = await request.json() as { intent?: string; message?: Message };
+			if (body.intent === "retry" && body.message) {
+				const { message } = body;
+				await context.cloudflare.env.MQCFGATEWAY.send({
+					id: message.id,
+					url: message.url,
+					filename: message.filename,
+					type: "in",
+					time: Date.now(),
+				} as MQCFGATEWAYMessage, {
+					contentType: "json",
+				});
+				return Response.json({ success: true });
+			}
+		} catch (e) {
+			console.error("Action error:", e);
+			return Response.json({ success: false, error: String(e) }, { status: 400 });
+		}
+	}
+
+	return loader({ request, context } as Route.LoaderArgs);
+}

--- a/src/front/panel/welcome.tsx
+++ b/src/front/panel/welcome.tsx
@@ -7,6 +7,7 @@ export function Welcome({ message, messages: initialMessages = [] }: { message: 
   const [offset, setOffset] = useState(initialMessages.length);
   const [hasMore, setHasMore] = useState(initialMessages.length >= 20);
   const [selectedMessage, setSelectedMessage] = useState<Message | null>(null);
+  const [retryLoading, setRetryLoading] = useState(false);
 
   const observer = useRef<IntersectionObserver | null>(null);
   const lastMessageElementRef = useCallback((node: HTMLElement | null) => {
@@ -53,6 +54,34 @@ export function Welcome({ message, messages: initialMessages = [] }: { message: 
       return url.pathname + url.search;
     } catch (e) {
       return urlStr;
+    }
+  };
+
+  const handleRetry = async () => {
+    if (!selectedMessage || retryLoading) return;
+    setRetryLoading(true);
+    try {
+        const res = await fetch("/panel/messages", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                intent: "retry",
+                message: selectedMessage,
+            }),
+        });
+        if (res.ok) {
+            alert("Retry sent successfully!");
+            setSelectedMessage(null);
+        } else {
+            alert("Failed to retry.");
+        }
+    } catch (e) {
+        console.error("Retry error:", e);
+        alert("An error occurred.");
+    } finally {
+        setRetryLoading(false);
     }
   };
 
@@ -140,7 +169,14 @@ export function Welcome({ message, messages: initialMessages = [] }: { message: 
                 </pre>
               </div>
             </div>
-            <div className="mt-4 pt-2 border-t dark:border-gray-800 flex justify-end">
+            <div className="mt-4 pt-2 border-t dark:border-gray-800 flex justify-end gap-2">
+                <button
+                    onClick={handleRetry}
+                    disabled={retryLoading}
+                    className="px-4 py-1 bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-400 rounded text-[10px] font-bold uppercase flex items-center gap-2"
+                >
+                    {retryLoading ? "Sending..." : "Retry"}
+                </button>
                 <button
                     onClick={() => setSelectedMessage(null)}
                     className="px-4 py-1 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded text-[10px] font-bold uppercase"


### PR DESCRIPTION
This change introduces a "RETRY" button in the log panel's message detail view. When clicked, it sends a POST request to the server, which then re-queues the original message into the Cloudflare Queue with `type: 'in'`, allowing the message to be re-processed.

Key changes:
- Frontend: Added state for retry loading, a `handleRetry` function, and the button itself in `src/front/panel/welcome.tsx`.
- Backend: Updated the `action` function in `src/front/.server/panel/panel.ts` to process the `retry` intent, utilizing the `MQCFGATEWAY` binding to send the message.
- Type Safety: Integrated `MQCFGATEWAYMessage` type for consistency.

Fixes #16

---
*PR created automatically by Jules for task [7127093017256950465](https://jules.google.com/task/7127093017256950465) started by @frkr*