### PR TITLE
Update Retry E2E Test to Match UI and API Changes

### DIFF
--- a/test/e2e/retry.spec.ts
+++ b/test/e2e/retry.spec.ts
@@ -19,24 +19,25 @@ test.describe('Retry Button Functionality', () => {
       message: 'Hello from Cloudflare'
     };
 
-    // Dialog handler
-    let dialogMessage = '';
-    page.on('dialog', async (dialog) => {
-      dialogMessage = dialog.message();
-      console.log('Dialog appeared:', dialogMessage);
-      await dialog.accept();
-    });
-
     // Mocking
     await page.route('**/*', async (route) => {
       const url = route.request().url();
-      if (url.includes('/panel') && (url.includes('json=1') || route.request().headers()['accept']?.includes('application/json'))) {
-         console.log('Mocking data request:', url);
+      const method = route.request().method();
+      if (url.includes('/panel/messages') && method === 'GET') {
+         console.log('Mocking GET data request:', url);
          return route.fulfill({
            status: 200,
            contentType: 'application/json',
            body: JSON.stringify(mockMessages),
          });
+      }
+      if (url.includes('/panel/messages') && method === 'POST') {
+        console.log('Mocking POST retry request:', url);
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        });
       }
       return route.continue();
     });
@@ -62,8 +63,8 @@ test.describe('Retry Button Functionality', () => {
     await expect(retryButton).toBeVisible();
     await retryButton.click();
 
-    // Verify alert message
-    console.log('Waiting for success alert');
-    await expect.poll(() => dialogMessage, { timeout: 5000 }).toContain('Retry sent successfully!');
+    // Verify success message in the custom modal
+    console.log('Waiting for success message');
+    await expect(page.getByText('Mensagem enviada com sucesso')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
The Playwright E2E test for the retry functionality was updated to reflect recent changes in the UI and API. Previously, the test expected a browser alert dialog, but the application now uses a custom React modal for success notifications. The test was also updated to explicitly mock both the message fetching (GET) and the retry action (POST) to the backend.

Tests results:
- Playwright E2E: 1 passed (retry.spec.ts)
- Vitest Unit: 14 passed (3 files)

Fixes #30

---
*PR created automatically by Jules for task [11309415244105593401](https://jules.google.com/task/11309415244105593401) started by @frkr*