### PR TITLE
Implement 30-day database purge for messages table

### DIFF
--- a/src/mq/database.json
+++ b/src/mq/database.json
@@ -1,4 +1,5 @@
 {
     "createTable": "CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, id_parent TEXT, url TEXT, filename TEXT NOT NULL, content TEXT, processed_at INTEGER NOT NULL, status TEXT NOT NULL, lab INTEGER)",
-    "insert": "INSERT INTO messages (id, id_parent, url, filename, content, processed_at, status, lab) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    "insert": "INSERT INTO messages (id, id_parent, url, filename, content, processed_at, status, lab) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    "deleteOld": "DELETE FROM messages WHERE processed_at < ?"
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,7 @@ import { HTTP_OK } from '~/lib/httpcodes';
 import MQStore from './mq/MQStore';
 import MQProc from './mq/MQProc';
 import MQCallback from './mq/MQCallback';
+import database from './mq/database.json';
 //endregion
 
 //region Inicializacao React Router
@@ -69,6 +70,8 @@ export default {
 			truncated = result.truncated;
 			cursor = result.truncated ? result.cursor : undefined;
 		}
+
+		await env.DB.prepare(database.deleteOld).bind(now - maxAgeMs).run();
 	},
 	
 	async queue(batch, env): Promise<void> {

--- a/test/mq/purge.spec.ts
+++ b/test/mq/purge.spec.ts
@@ -1,0 +1,49 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '../../src/worker';
+import database from '../../src/mq/database.json';
+
+describe('Worker Purge', () => {
+	beforeEach(async () => {
+		// Initialize the database schema
+		await env.DB.prepare(database.createTable).run();
+		// Clear the table
+		await env.DB.prepare('DELETE FROM messages').run();
+	});
+
+	it('should delete messages older than 30 days and keep recent ones', async () => {
+		const now = Date.now();
+		const thirtyOneDaysAgo = now - (31 * 24 * 60 * 60 * 1000);
+		const oneDayAgo = now - (1 * 24 * 60 * 60 * 1000);
+
+		// Insert an old message
+		await env.DB.prepare(database.insert)
+			.bind('old-id', 'parent-id', 'http://example.com/old', 'old.txt', 'old content', thirtyOneDaysAgo, 'processed', 0)
+			.run();
+
+		// Insert a recent message
+		await env.DB.prepare(database.insert)
+			.bind('recent-id', 'parent-id', 'http://example.com/recent', 'recent.txt', 'recent content', oneDayAgo, 'processed', 0)
+			.run();
+
+		// Verify they both exist
+		let count = await env.DB.prepare('SELECT COUNT(*) as count FROM messages').first('count');
+		expect(count).toBe(2);
+
+		// Trigger the scheduled handler
+		const ctx = createExecutionContext();
+		const event: ScheduledEvent = {
+			cron: '',
+			scheduledTime: now,
+			noWait: () => {},
+		};
+
+		await worker.scheduled(event, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// Verify only the recent message remains
+		const messages: any[] = (await env.DB.prepare('SELECT id FROM messages').all()).results;
+		expect(messages.length).toBe(1);
+		expect(messages[0].id).toBe('recent-id');
+	});
+});


### PR DESCRIPTION
This PR implements an automated 30-day purge for the `messages` D1 table, aligning its data retention policy with the existing R2 storage cleanup.

Key changes:
- **Database Query**: Introduced `deleteOld` in `src/mq/database.json`.
- **Worker Logic**: Enhanced the `scheduled` cron handler in `src/worker.ts` to calculate the 30-day cutoff and remove old database records.
- **Verification**: Added `test/mq/purge.spec.ts` which simulates the scheduled event and confirms correct data expiration.

Note: Pre-existing failures in `test/mq/mqproc/MQProc.spec.ts` were observed but not addressed as they are outside the scope of this task. All new and relevant tests pass.

Fixes #37

---
*PR created automatically by Jules for task [5413761858200286890](https://jules.google.com/task/5413761858200286890) started by @frkr*