### PR TITLE
🧹 remove console.log from worker.ts

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -62,7 +62,6 @@ export default {
 			const result: R2Objects = await env.CFGATEWAY.list({ cursor });
 			for (const object of result.objects) {
 				if (now - object.uploaded.getTime() > maxAgeMs) {
-					console.log(`Deleting old file: ${object.key}`);
 					await env.CFGATEWAY.delete(object.key);
 				}
 			}


### PR DESCRIPTION
🎯 **What:** Removed a `console.log` statement from the `scheduled` function in `src/worker.ts` that was logging R2 file deletions.
💡 **Why:** Console logs used for debugging can clutter production logs and should be removed once the functionality is verified. This improves the maintainability and readability of the code health.
✅ **Verification:** Manually verified the change by inspecting the code. Attempted to run automated tests, but were blocked by network issues in the sandbox. Code review confirmed the change is safe and correct.
✨ **Result:** Cleaner logs and better code health.

---
*PR created automatically by Jules for task [2820894819573974489](https://jules.google.com/task/2820894819573974489) started by @frkr*