### PR TITLE
🧪 [testing improvement] Add test for mainroute error path (422)

### DIFF
--- a/test/front/.server/mainroute/mainroute.spec.ts
+++ b/test/front/.server/mainroute/mainroute.spec.ts
@@ -1,0 +1,36 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { action } from "../../../../src/front/.server/mainroute/mainroute";
+
+describe("mainroute", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("responds with 422 Unprocessable Entity for empty or short content", async () => {
+		const request = new Request("http://example.com", {
+			method: "POST",
+			body: "short",
+		});
+
+		const context = {
+			cloudflare: {
+				env: env
+			}
+		};
+
+		// We need to capture the promise, then advance timers, then await
+		const responsePromise = action({ request, context } as any);
+
+		// Run all timers to bypass the 5-second delay
+		await vi.runAllTimersAsync();
+
+		const response = await responsePromise;
+
+		expect(response.status).toBe(422);
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to cover the `catch` block (error path) inside `mainroute.ts`, which triggers a 5-second anti-abuse delay and returns a 422 status.
📊 **Coverage:** Specifically covers the scenario where the request body is too short or empty, causing `handleRequest` to throw an error, hit the catch block, and return HTTP_UNPROCESSABLE_ENTITY.
✨ **Result:** Increased unit test coverage and confidence in the error handling of the main route. Test execution remains fast by utilizing `vi.useFakeTimers()` to bypass the real 5-second wait.

---
*PR created automatically by Jules for task [7590394287677768148](https://jules.google.com/task/7590394287677768148) started by @frkr*