### PR TITLE
🧪 Add tests for pathroute.ts header parser

### DIFF
--- a/pr_comments.txt
+++ b/pr_comments.txt
@@ -1,0 +1,22 @@
+## Test Results
+
+The new tests for the `pathroute.ts` header parser were added and executed successfully. Here is the summary:
+
+```
+ Test Files  11 passed (11)
+      Tests  46 passed (46)
+   Start at  18:51:21
+   Duration  7.39s
+```
+
+**New test file added:** `test/front/lib/pathroute.spec.ts`
+
+**Cases covered for `toPathRoute` / `parseHeaderEntries`:**
+- `should parse valid array of header entries`
+- `should parse valid record of headers`
+- `should return empty array for null headers`
+- `should return empty array for empty string headers`
+- `should return empty array for "null" string headers`
+- `should return empty array for invalid JSON string`
+- `should return empty array for malformed JSON string "{"`
+- `should ignore invalid entries in an array`

--- a/test/front/lib/pathroute.spec.ts
+++ b/test/front/lib/pathroute.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { toPathRoute, type PathRouteRow } from '../../../src/front/lib/pathroute';
+
+describe('pathroute', () => {
+	describe('toPathRoute', () => {
+		const baseRow: PathRouteRow = {
+			id: 'test-id',
+			path: '/test-path',
+			destiny: 'https://example.com',
+			callback: null,
+			method_destiny: 'POST',
+			method_callback: null,
+			content_type_destiny: null,
+			content_type_callback: null,
+			headers_destiny: null,
+			headers_callback: null,
+			enabled: 1,
+			created_at: 1234567890,
+			updated_at: 1234567890
+		};
+
+		it('should parse valid array of header entries', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: JSON.stringify([
+					{ key: 'X-Test-1', value: 'value1' },
+					{ key: 'X-Test-2', value: 'value2' }
+				])
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([
+				{ key: 'X-Test-1', value: 'value1' },
+				{ key: 'X-Test-2', value: 'value2' }
+			]);
+		});
+
+		it('should parse valid record of headers', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: JSON.stringify({
+					'X-Test-1': 'value1',
+					'X-Test-2': 'value2'
+				})
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([
+				{ key: 'X-Test-1', value: 'value1' },
+				{ key: 'X-Test-2', value: 'value2' }
+			]);
+		});
+
+		it('should return empty array for null headers', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: null
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([]);
+		});
+
+		it('should return empty array for empty string headers', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: ''
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([]);
+		});
+
+		it('should return empty array for "null" string headers', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: 'null'
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([]);
+		});
+
+		it('should return empty array for invalid JSON string', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: 'invalid-json'
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([]);
+		});
+
+		it('should return empty array for malformed JSON string "{"', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: '{'
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([]);
+		});
+
+		it('should ignore invalid entries in an array', () => {
+			const row = {
+				...baseRow,
+				headers_destiny: JSON.stringify([
+					{ key: 'Valid', value: 'value' },
+					{ missingKey: 'invalid' },
+					null,
+					{ key: 123, value: 'invalid key type' },
+					{ key: 'MissingValue' }
+				])
+			};
+
+			const result = toPathRoute(row);
+			expect(result.headersDestiny).toEqual([
+				{ key: 'Valid', value: 'value' },
+				{ key: 'MissingValue', value: '' } // missing value defaults to ''
+			]);
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive test coverage for `pathroute.ts` header parser (`parseHeaderEntries` and `toPathRoute`). This addresses a gap where invalid header parsing edge cases were missing.

📊 **Coverage:** The new tests in `test/front/lib/pathroute.spec.ts` cover:
- Valid header structures (array of `PathRouteHeaderEntry` and `MQCFGATEWAYHeaders` records)
- Edge cases (`null`, `""`, `"null"`)
- Invalid format handling (invalid JSON strings, malformed JSON like `"{ "`)
- Arrays containing invalid entry types or missing required properties

✨ **Result:** Test coverage for `pathroute.ts` header parsing has been fully implemented, improving confidence when validating stored headers data.

## Test Results

The new tests for the `pathroute.ts` header parser were added and executed successfully. Here is the summary:

```
 Test Files  11 passed (11)
      Tests  46 passed (46)
   Start at  18:51:21
   Duration  7.39s
```

**New test file added:** `test/front/lib/pathroute.spec.ts`

**Cases covered for `toPathRoute` / `parseHeaderEntries`:**
- `should parse valid array of header entries`
- `should parse valid record of headers`
- `should return empty array for null headers`
- `should return empty array for empty string headers`
- `should return empty array for "null" string headers`
- `should return empty array for invalid JSON string`
- `should return empty array for malformed JSON string "{"`
- `should ignore invalid entries in an array`

---
*PR created automatically by Jules for task [12357331306306602290](https://jules.google.com/task/12357331306306602290) started by @frkr*