### PR TITLE
Add multilingual READMEs with feature highlights

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,68 @@
+# Cloudflare Gateway
+
+Cloudflare Gateway es una herramienta potente y ligera diseñada para almacenar, visualizar y reenviar (replay) solicitudes HTTP (webhooks). Construido sobre el ecosistema de Cloudflare, aprovecha servicios de alto rendimiento para proporcionar una solución escalable para la depuración y el monitoreo de comunicaciones asíncronas.
+
+## 🚀 Características
+
+- **Almacenamiento de Webhooks**: Captura y almacena solicitudes y respuestas HTTP entrantes.
+- **Reenvío de Mensajes**: Reintente y reenvíe mensajes fácilmente directamente desde el panel de control.
+- **Panel de Administración**: Una interfaz de usuario moderna construida con React Router 7 para visualizar registros y gestionar mensajes.
+- **Procesamiento Asíncrono**: Utiliza Cloudflare Queues para el procesamiento confiable de tareas en segundo plano.
+- **Almacenamiento Persistente**: Utiliza Cloudflare D1 para metadatos y R2 para el almacenamiento de contenido de gran tamaño.
+- **Limpieza Automática**: Incluye una tarea programada (Cron) para purgar datos antiguos basados en políticas de retención configurables.
+- **Seguridad**: Rutas protegidas mediante autenticación por Token de Administrador.
+
+## 🛠 Tecnologías
+
+- **Runtime**: Cloudflare Workers
+- **Base de Datos**: Cloudflare D1 (SQL)
+- **Almacenamiento de Objetos**: Cloudflare R2
+- **Mensajería**: Cloudflare Queues
+- **Frontend**: React Router 7, React 19, Tailwind CSS
+- **Herramienta de Construcción**: Vite
+- **Pruebas**: Vitest y Playwright
+
+## 📥 Primeros Pasos
+
+### Requisitos Previos
+
+- [Node.js](https://nodejs.org/) (se recomienda la última versión LTS)
+- [pnpm](https://pnpm.io/)
+- [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+### Instalación
+
+1. Clone el repositorio.
+2. Instale las dependencias:
+   ```bash
+   pnpm install
+   ```
+3. Inicialice la base de datos local:
+   ```bash
+   pnpm wrangler d1 execute cfgateway --local --file=./path/to/schema.sql
+   ```
+
+### Desarrollo Local
+
+Ejecute el servidor de desarrollo:
+```bash
+pnpm run dev
+```
+
+### Despliegue
+
+Despliegue en Cloudflare Workers:
+```bash
+pnpm run deploy
+```
+
+## ⚙️ Configuración
+
+Las variables de entorno y los bindings se gestionan en `wrangler.jsonc`:
+
+- `ADMIN_TOKEN`: Token de seguridad para acceder al panel.
+- `MAX_AGE_DAYS`: Período de retención de mensajes (por defecto: 30 días).
+
+## 📄 Licencia
+
+Este proyecto está bajo la Licencia MIT - vea el archivo [LICENSE](LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,68 @@
 # Cloudflare Gateway
 
-Visualizer Tool for Webhook and Replays
+Cloudflare Gateway is a powerful and lightweight tool designed to store, visualize, and replay HTTP requests (webhooks). Built on top of the Cloudflare ecosystem, it leverages high-performance services to provide a scalable solution for debugging and monitoring asynchronous communications.
+
+## 🚀 Features
+
+- **Webhook Storage**: Captures and stores incoming HTTP requests and responses.
+- **Message Replay**: Easily retry and replay messages directly from the dashboard.
+- **Admin Panel**: A modern UI built with React Router 7 to visualize logs and manage messages.
+- **Asynchronous Processing**: Uses Cloudflare Queues for reliable, background processing of tasks.
+- **Persistent Storage**: Utilizes Cloudflare D1 for metadata and R2 for large content storage.
+- **Automated Cleanup**: Includes a scheduled task (Cron) to purge old data based on configurable retention policies.
+- **Security**: Protected routes via Admin Token authentication.
+
+## 🛠 Tech Stack
+
+- **Runtime**: Cloudflare Workers
+- **Database**: Cloudflare D1 (SQL)
+- **Object Storage**: Cloudflare R2
+- **Messaging**: Cloudflare Queues
+- **Frontend**: React Router 7, React 19, Tailwind CSS
+- **Build Tool**: Vite
+- **Testing**: Vitest & Playwright
+
+## 📥 Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (latest LTS recommended)
+- [pnpm](https://pnpm.io/)
+- [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+### Installation
+
+1. Clone the repository.
+2. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Initialize the local database:
+   ```bash
+   pnpm wrangler d1 execute cfgateway --local --file=./path/to/schema.sql
+   ```
+
+### Local Development
+
+Run the development server:
+```bash
+pnpm run dev
+```
+
+### Deployment
+
+Deploy to Cloudflare Workers:
+```bash
+pnpm run deploy
+```
+
+## ⚙️ Configuration
+
+Environment variables and bindings are managed in `wrangler.jsonc`:
+
+- `ADMIN_TOKEN`: Security token for accessing the panel.
+- `MAX_AGE_DAYS`: Retention period for messages (default: 30 days).
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,68 @@
+# Cloudflare Gateway
+
+Cloudflare Gateway é uma ferramenta poderosa e leve projetada para armazenar, visualizar e reenviar (replay) requisições HTTP (webhooks). Construído sobre o ecossistema Cloudflare, ele utiliza serviços de alta performance para fornecer uma solução escalável para depuração e monitoramento de comunicações assíncronas.
+
+## 🚀 Funcionalidades
+
+- **Armazenamento de Webhooks**: Captura e armazena requisições e respostas HTTP recebidas.
+- **Replay de Mensagens**: Reenvie mensagens facilmente diretamente do painel de controle.
+- **Painel Administrativo**: Uma interface moderna construída com React Router 7 para visualizar logs e gerenciar mensagens.
+- **Processamento Assíncrono**: Utiliza Cloudflare Queues para processamento de tarefas em segundo plano de forma confiável.
+- **Armazenamento Persistente**: Utiliza Cloudflare D1 para metadados e R2 para armazenamento de grandes conteúdos.
+- **Limpeza Automática**: Inclui uma tarefa agendada (Cron) para remover dados antigos com base em políticas de retenção configuráveis.
+- **Segurança**: Rotas protegidas via autenticação por Admin Token.
+
+## 🛠 Tecnologias
+
+- **Runtime**: Cloudflare Workers
+- **Banco de Dados**: Cloudflare D1 (SQL)
+- **Armazenamento de Objetos**: Cloudflare R2
+- **Mensageria**: Cloudflare Queues
+- **Frontend**: React Router 7, React 19, Tailwind CSS
+- **Build Tool**: Vite
+- **Testes**: Vitest & Playwright
+
+## 📥 Primeiros Passos
+
+### Pré-requisitos
+
+- [Node.js](https://nodejs.org/) (recomendado última versão LTS)
+- [pnpm](https://pnpm.io/)
+- [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+### Instalação
+
+1. Clone o repositório.
+2. Instale as dependências:
+   ```bash
+   pnpm install
+   ```
+3. Inicialize o banco de dados local:
+   ```bash
+   pnpm wrangler d1 execute cfgateway --local --file=./path/to/schema.sql
+   ```
+
+### Desenvolvimento Local
+
+Execute o servidor de desenvolvimento:
+```bash
+pnpm run dev
+```
+
+### Deploy
+
+Faça o deploy para o Cloudflare Workers:
+```bash
+pnpm run deploy
+```
+
+## ⚙️ Configuração
+
+As variáveis de ambiente e bindings são gerenciados no arquivo `wrangler.jsonc`:
+
+- `ADMIN_TOKEN`: Token de segurança para acessar o painel.
+- `MAX_AGE_DAYS`: Período de retenção das mensagens (padrão: 30 dias).
+
+## 📄 Licença
+
+Este projeto está licenciado sob a Licença MIT - veja o arquivo [LICENSE](LICENSE) para mais detalhes.


### PR DESCRIPTION
This PR adds comprehensive documentation for the Cloudflare Gateway project. It includes a main README.md in English and translated versions in Portuguese (pt-br) and Spanish (es), as per the project's documentation guidelines in AGENTS.md. The READMEs highlight the core features, technology stack, and provide basic instructions for installation, local development, and deployment.

Fixes #63

---
*PR created automatically by Jules for task [17978290303800911235](https://jules.google.com/task/17978290303800911235) started by @frkr*