### PR TITLE
🛡️ Sentinel: [HIGH] Prevent SSRF in path routes validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was verifying `ADMIN_TOKEN` authentication tokens using standard string equality (`===`).
 **Learning:** This approach is susceptible to timing attacks, where an attacker can theoretically determine the expected token by measuring the time it takes for the comparison to fail. In Cloudflare Workers with `nodejs_compat` enabled, one could use `node:crypto` `timingSafeEqual`, however, for simplicity and to avoid Buffer dependencies, a custom constant-time XOR-based string comparison function (`safeCompare`) can also provide protection.
 **Prevention:** Always use constant-time string comparison methods when checking passwords, tokens, API keys, or any secret data.
+
+## 2024-05-14 - Prevent SSRF in path routes configuration
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) because the path routes API (`src/front/.server/panel/paths.ts`) did not validate the protocol of user-provided `destiny` and `callback` URLs, potentially allowing malicious internal URLs like `file://` or `gopher://`.
+**Learning:** Simply using `new URL(urlString)` is insufficient for security if the resulting protocol is not validated. This can enable SSRF attacks, allowing potential internal network probing or unauthorized access to internal resources.
+**Prevention:** Always strictly enforce `http:` or `https:` protocols using the `URL` object (`url.protocol === "http:" || url.protocol === "https:"`) when accepting user-provided outbound request destinations.

--- a/src/front/.server/panel/paths.ts
+++ b/src/front/.server/panel/paths.ts
@@ -67,7 +67,10 @@ function validatePayload(payload: PathRoutePayload) {
 		throw new Error('Destiny is required.');
 	}
 	
-	new URL(destiny);
+	const destinyUrl = new URL(destiny);
+	if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+		throw new Error('Destiny URL must use http or https protocol.');
+	}
 	
 	const methodDestiny = normalizeMethodDestiny(String(payload.methodDestiny || 'POST'));
 	if (!isPathRouteMethod(methodDestiny)) {
@@ -76,7 +79,10 @@ function validatePayload(payload: PathRoutePayload) {
 	
 	const callback = String(payload.callback || '').trim();
 	if (callback) {
-		new URL(callback);
+		const callbackUrl = new URL(callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			throw new Error('Callback URL must use http or https protocol.');
+		}
 	}
 	
 	const methodCallback = normalizeMethodDestiny(String(payload.methodCallback || 'POST'));


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Prevent SSRF in path routes validation

🚨 Severity: HIGH
💡 Vulnerability: The application did not validate the protocol for the user-supplied `destiny` and `callback` URLs in `src/front/.server/panel/paths.ts`.
🎯 Impact: This allowed malicious internal URLs (e.g., `file://`, `gopher://`, `localhost`) to be accepted, leading to potential Server-Side Request Forgery (SSRF) and internal network probing.
🔧 Fix: Validated that `new URL(destiny)` and `new URL(callback)` strict protocols are either `http:` or `https:`.
✅ Verification: Ran `pnpm test` and ensured `paths.spec.ts` and all other tests pass successfully. Documented learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5416366887217802651](https://jules.google.com/task/5416366887217802651) started by @frkr*