### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in path routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was verifying `ADMIN_TOKEN` authentication tokens using standard string equality (`===`).
 **Learning:** This approach is susceptible to timing attacks, where an attacker can theoretically determine the expected token by measuring the time it takes for the comparison to fail. In Cloudflare Workers with `nodejs_compat` enabled, one could use `node:crypto` `timingSafeEqual`, however, for simplicity and to avoid Buffer dependencies, a custom constant-time XOR-based string comparison function (`safeCompare`) can also provide protection.
 **Prevention:** Always use constant-time string comparison methods when checking passwords, tokens, API keys, or any secret data.
+
+## 2025-02-14 - Fix Server-Side Request Forgery (SSRF) via invalid protocols
+**Vulnerability:** The application was verifying if `destiny` and `callback` fields were valid URLs in `src/front/.server/panel/paths.ts`, but it didn't restrict the URL protocol to HTTP/HTTPS.
+**Learning:** `new URL()` simply validates the string as any URL (e.g., `ftp://`, `file://`, `data://`). When used in server-side `fetch` calls, an attacker could abuse these URL inputs to make the application read local files or connect to internal services via SSRF (Server-Side Request Forgery).
+**Prevention:** Always restrict user-provided URLs intended for external HTTP requests to `http:` and `https:` protocols. Validate `url.protocol` explicitly.

--- a/src/front/.server/panel/paths.ts
+++ b/src/front/.server/panel/paths.ts
@@ -67,7 +67,10 @@ function validatePayload(payload: PathRoutePayload) {
 		throw new Error('Destiny is required.');
 	}
 	
-	new URL(destiny);
+	const destinyUrl = new URL(destiny);
+	if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+		throw new Error('Destiny URL must use http or https protocol.');
+	}
 	
 	const methodDestiny = normalizeMethodDestiny(String(payload.methodDestiny || 'POST'));
 	if (!isPathRouteMethod(methodDestiny)) {
@@ -76,7 +79,10 @@ function validatePayload(payload: PathRoutePayload) {
 	
 	const callback = String(payload.callback || '').trim();
 	if (callback) {
-		new URL(callback);
+		const callbackUrl = new URL(callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			throw new Error('Callback URL must use http or https protocol.');
+		}
 	}
 	
 	const methodCallback = normalizeMethodDestiny(String(payload.methodCallback || 'POST'));

--- a/test/front/.server/panel/paths.spec.ts
+++ b/test/front/.server/panel/paths.spec.ts
@@ -178,6 +178,73 @@ describe('Panel Path Routes - Action', () => {
 		expect(data.routes).toHaveLength(0);
 	});
 	
+	it('should reject ftp or file protocol in destiny URL to prevent SSRF', async () => {
+		const context = {
+			cloudflare: {
+				env: {
+					...env,
+					ADMIN_TOKEN: 'supersecret'
+				}
+			}
+		} as any;
+
+		const createRequest = new Request('http://example.com/panel/paths?json=1', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer supersecret'
+			},
+			body: JSON.stringify({
+				intent: 'save',
+				route: {
+					path: '/ssrf-test-destiny/',
+					destiny: 'ftp://evil.com/hook',
+					methodDestiny: 'POST'
+				}
+			})
+		});
+
+		const response = await action({ request: createRequest, context, params: {} } as any);
+		const data = await (response as Response).json() as { success: boolean; error?: string };
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Destiny URL must use http or https protocol.');
+	});
+
+	it('should reject ftp or file protocol in callback URL to prevent SSRF', async () => {
+		const context = {
+			cloudflare: {
+				env: {
+					...env,
+					ADMIN_TOKEN: 'supersecret'
+				}
+			}
+		} as any;
+
+		const createRequest = new Request('http://example.com/panel/paths?json=1', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer supersecret'
+			},
+			body: JSON.stringify({
+				intent: 'save',
+				route: {
+					path: '/ssrf-test-callback/',
+					destiny: 'https://destiny.example.com/hook',
+					callback: 'file:///etc/passwd',
+					methodDestiny: 'POST'
+				}
+			})
+		});
+
+		const response = await action({ request: createRequest, context, params: {} } as any);
+		const data = await (response as Response).json() as { success: boolean; error?: string };
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Callback URL must use http or https protocol.');
+	});
+
 	it('should read old path records without async extension columns filled', async () => {
 		const now = Date.now();
 		await env.DB.prepare('INSERT INTO paths (id, path, destiny, method_destiny, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) via invalid URL protocols. The application used `new URL(destiny)` and `new URL(callback)` to validate inputs, which allows protocols like `file://` and `ftp://`. Since these inputs are later used in server-side `fetch` calls, an attacker could potentially force the server to read local files or connect to internal services.
🎯 **Impact:** Potential unauthorized access to internal networks or local file reading on the server.
🔧 **Fix:** Explicitly validate `url.protocol` and reject anything that isn't `http:` or `https:`. Added unit tests for these cases.
✅ **Verification:** Run `pnpm run test test/front/.server/panel/paths.spec.ts` and see that tests pass checking for SSRF protection.

---
*PR created automatically by Jules for task [487501659224268239](https://jules.google.com/task/487501659224268239) started by @frkr*