### PR TITLE
🧪 test: add missing R2 file test case to MQCallback

### DIFF
--- a/test/mq/mqcallback/MQCallback.spec.ts
+++ b/test/mq/mqcallback/MQCallback.spec.ts
@@ -45,4 +45,32 @@ describe('MQCallback', () => {
 		expect(stored?.url).toBe('http://callback.example.com');
 		expect(rawmsg.retry).not.toHaveBeenCalled();
 	});
+
+	it('should store the message as lost if R2 file reading throws an error', async () => {
+		const rawmsg = {
+			body: {
+				id: 'callback-missing-id',
+				url: 'http://callback.example.com',
+				filename: 'missing-test.txt',
+				time: Date.now(),
+				type: 'callback'
+			},
+			attempts: 1,
+			retry: vi.fn(),
+			ack: vi.fn()
+		} as any;
+
+		// Mock CFGATEWAY.get to throw an error
+		vi.spyOn(env.CFGATEWAY, 'get').mockRejectedValueOnce(new Error('Simulated R2 error'));
+
+		await MQCallback(rawmsg, env);
+
+		const stored = await env.DB.prepare('SELECT status, url FROM messages WHERE id_parent = ?')
+			.bind('callback-missing-id')
+			.first<{ status: string; url: string }>();
+
+		expect(stored?.status).toBe('lost');
+		expect(stored?.url).toBe('http://callback.example.com');
+		expect(rawmsg.retry).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `MQCallback` when `env.CFGATEWAY.get` throws an error.
📊 **Coverage:** Covers the catch block in `MQCallback.ts` during R2 file retrieval which results in falling through to `!asyncContent` condition.
✨ **Result:** Enhanced test suite reliability by simulating an R2 failure, ensuring the database correctly marks the message as `lost` without triggering unexpected retries.

---
*PR created automatically by Jules for task [11618819319552591386](https://jules.google.com/task/11618819319552591386) started by @frkr*