### PR TITLE
🧹 Refactor R2 file retrieval and JSON parsing into shared utility

### DIFF
--- a/src/front/lib/mqr2.ts
+++ b/src/front/lib/mqr2.ts
@@ -1,0 +1,26 @@
+
+export async function readR2Text(bucket: R2Bucket, filename?: string): Promise<string | null> {
+	if (!filename) return null;
+	try {
+		const r2Object = await bucket.get(filename);
+		if (r2Object) {
+			return await r2Object.text();
+		}
+	} catch (e) {
+		console.error('Error reading file from R2:', e);
+	}
+	return null;
+}
+
+export async function readR2Json<T>(bucket: R2Bucket, filename?: string, logError: boolean = true): Promise<T | null> {
+	const text = await readR2Text(bucket, filename);
+	if (!text) return null;
+	try {
+		return JSON.parse(text) as T;
+	} catch (e) {
+		if (logError) {
+			console.error('Error parsing JSON from R2:', e);
+		}
+	}
+	return null;
+}

--- a/src/mq/MQCallback.ts
+++ b/src/mq/MQCallback.ts
@@ -2,22 +2,13 @@ import type { MQCFGATEWAYMessage, MQCFGATEWAYMessageAsync } from '@/MQCFGATEWAY'
 import MQStore from './MQStore';
 import randomHEX from '@/randomHEX';
 import mqfilename from '@/mqfilename';
+import { readR2Json } from '@/mqr2';
 
 export default async function(rawmsg: Message<unknown>, env: Env) {
 	
 	let msg = rawmsg.body as MQCFGATEWAYMessage;
 	
-	let asyncContent: MQCFGATEWAYMessageAsync | null = null;
-	if (msg.filename) {
-		try {
-			let r2Object = await env.CFGATEWAY.get(msg.filename);
-			if (r2Object) {
-				asyncContent = JSON.parse(await r2Object.text());
-			}
-		} catch (e) {
-			console.error('Error reading file from R2:', e);
-		}
-	}
+	let asyncContent = await readR2Json<MQCFGATEWAYMessageAsync>(env.CFGATEWAY, msg?.filename);
 	
 	if (!asyncContent || !asyncContent.callback) {
 		await MQStore(rawmsg, env, {

--- a/src/mq/MQDestiny.ts
+++ b/src/mq/MQDestiny.ts
@@ -2,22 +2,13 @@ import MQStore from './MQStore';
 import type { MQCFGATEWAYMessage, MQCFGATEWAYMessageAsync } from '@/MQCFGATEWAY';
 import randomHEX from '@/randomHEX';
 import mqfilename from '@/mqfilename';
+import { readR2Json } from '@/mqr2';
 
 export default async function(rawmsg: Message<unknown>, env: Env) {
 	
 	let msg = rawmsg.body as MQCFGATEWAYMessage;
 	
-	let asyncContent: MQCFGATEWAYMessageAsync | null = null;
-	if (msg.filename) {
-		try {
-			let r2Object = await env.CFGATEWAY.get(msg.filename);
-			if (r2Object) {
-				asyncContent = JSON.parse(await r2Object.text());
-			}
-		} catch (e) {
-			console.error('Error reading file from R2:', e);
-		}
-	}
+	let asyncContent = await readR2Json<MQCFGATEWAYMessageAsync>(env.CFGATEWAY, msg?.filename);
 	
 	if (!asyncContent || !asyncContent.destiny) {
 		await MQStore(rawmsg, env, {

--- a/src/mq/MQProc.ts
+++ b/src/mq/MQProc.ts
@@ -3,6 +3,7 @@ import database from '@/pathroute.database.json';
 import { ensurePathRoutesTable, normalizePathKey, toPathRoute, toPathRouteAsync, type PathRouteRow } from '@/pathroute';
 import MQStore from './MQStore';
 import MQDestiny from './MQDestiny';
+import { readR2Text } from '@/mqr2';
 
 async function storeLost(rawmsg: Message<unknown>, env: Env) {
 	await MQStore(rawmsg, env, {
@@ -12,16 +13,11 @@ async function storeLost(rawmsg: Message<unknown>, env: Env) {
 }
 
 async function hydrateDynamicRoute(msg: MQCFGATEWAYMessage, route: PathRouteRow, env: Env) {
-	if (!msg.filename) {
+	const rawContent = await readR2Text(env.CFGATEWAY, msg?.filename);
+	if (!rawContent) {
 		return false;
 	}
 	
-	const r2Object = await env.CFGATEWAY.get(msg.filename);
-	if (!r2Object) {
-		return false;
-	}
-	
-	const rawContent = await r2Object.text();
 	let asyncContent: MQCFGATEWAYMessageAsync = {
 		content: rawContent
 	};

--- a/src/mq/MQStore.ts
+++ b/src/mq/MQStore.ts
@@ -1,6 +1,7 @@
 import type { MQCFGATEWAYMessage, MQCFGATEWAYType } from '@/MQCFGATEWAY';
 import database from './database.json';
 import randomHEX from '@/randomHEX';
+import { readR2Text } from '@/mqr2';
 
 type MQStoreParams = {
 	type?: MQCFGATEWAYType,
@@ -16,18 +17,7 @@ export default async function(
 	
 	let msg = rawmsg.body as MQCFGATEWAYMessage;
 	
-	let content = null;
-	
-	try {
-		if (!props?.notread && msg?.filename) {
-			let r2Object = await env.CFGATEWAY.get(msg.filename);
-			if (r2Object) {
-				content = await r2Object.text();
-			}
-		}
-	} catch (e) {
-		console.error('Error reading file from R2:', e);
-	}
+	let content = props?.notread ? null : await readR2Text(env.CFGATEWAY, msg?.filename);
 	
 	await env.DB.prepare(
 		database.insert


### PR DESCRIPTION
Extracted duplicated R2 retrieval and JSON parsing logic into new `readR2Text` and `readR2Json` utilities in `src/front/lib/mqr2.ts`. Updated `MQDestiny`, `MQCallback`, `MQStore`, and `MQProc` to use these utilities, improving maintainability and reducing code duplication. Ensured null-safety for message property access and followed existing path alias conventions.