### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in background workers

### DIFF
--- a/src/mq/MQCallback.ts
+++ b/src/mq/MQCallback.ts
@@ -19,6 +19,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const callbackUrl = new URL(asyncContent.callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersCallback) {
 			for (let [key, value] of Object.entries(asyncContent.headersCallback)) {

--- a/src/mq/MQDestiny.ts
+++ b/src/mq/MQDestiny.ts
@@ -19,6 +19,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const destinyUrl = new URL(asyncContent.destiny);
+		if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersDestiny) {
 			for (let [key, value] of Object.entries(asyncContent.headersDestiny)) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) vulnerability in background workers processing messages. The workers blindly passed `asyncContent.destiny` and `asyncContent.callback` to `fetch()` without verifying the URL protocol. This meant that an attacker who managed to queue an asynchronous message could supply a non-HTTP URL (like `file://`, `ftp://`, etc.) causing the worker to interact with internal or unexpected external systems. 
🎯 Impact: High. Depending on the Cloudflare Worker runtime restrictions or eventual deployment context, fetching unintended protocols or internal endpoints can lead to data leakage, bypassing network access controls, and probing internal infrastructure.
🔧 Fix:
- Handled potential errors when parsing URLs by wrapping `new URL()` in a try/catch block.
- Implemented protocol validation ensuring that the URL uses the `http:` or `https:` scheme. 
- If an invalid or unallowed protocol is detected, the message state is immediately set to `'error'` and processing returns early, preventing infinite loops and dangerous operations.
✅ Verification: Tested against the full test suite (`pnpm test`), ensuring that 12 test files passed successfully, without regressions.

---
*PR created automatically by Jules for task [1502159186315946944](https://jules.google.com/task/1502159186315946944) started by @frkr*