### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in background workers

### DIFF
--- a/src/mq/MQCallback.ts
+++ b/src/mq/MQCallback.ts
@@ -17,6 +17,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 		});
 		return;
 	}
+
+	try {
+		const callbackUrl = new URL(asyncContent.callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
 	
 	try {
 		let headers = new Headers();

--- a/src/mq/MQDestiny.ts
+++ b/src/mq/MQDestiny.ts
@@ -17,6 +17,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 		});
 		return;
 	}
+
+	try {
+		const destinyUrl = new URL(asyncContent.destiny);
+		if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
 	
 	try {
 		let headers = new Headers();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The background queue processors (`MQDestiny.ts` and `MQCallback.ts`) did not validate the protocol of user-hydrated or externally supplied URLs before making outbound `fetch` requests. 
🎯 Impact: This lack of validation could allow Server-Side Request Forgery (SSRF). An attacker could exploit this by crafting payloads with `file:`, `javascript:`, or `data:` protocols, forcing the server to read local files or make arbitrary internal requests, potentially bypassing security policies.
🔧 Fix: Parsed the destination and callback URLs using the `URL` object and enforced a strict check to ensure their protocol is either `http:` or `https:`. If an invalid or malicious protocol is detected, the URL is rejected and the message is safely logged as 'error' in `MQStore`, returning early to halt execution without throwing an unhandled exception or leaking information.
✅ Verification: Ensure the test suite continues to pass (`pnpm test`). The `fetch` function will no longer execute for non-HTTP(S) URLs in background processes.

---
*PR created automatically by Jules for task [14747614525031795322](https://jules.google.com/task/14747614525031795322) started by @frkr*