### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in MQ queue fetch handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The application was using `.startsWith('/async/')` and `.startsWith('/store/')` to protect sensitive endpoints, allowing an attacker to request `/async-bypass` and completely bypass the authentication checks.
 **Learning:** Checking route paths purely by checking if they start with a string containing a trailing slash might ignore the root path (without trailing slash), and leaving off the trailing slash might allow matching unintended sibling paths.
 **Prevention:** Always verify paths against exact matches (e.g. `=== '/async'`) OR prefix matches using trailing slashes (`.startsWith('/async/')`). Avoid loose prefix matching (`.startsWith('/async')`).
+## 2024-08-06 - Prevent SSRF in MQ Destinations
+**Vulnerability:** URLs fetched in background queue handlers (`MQDestiny.ts` and `MQCallback.ts`) were not validated for secure protocols before being passed to `fetch()`, potentially allowing SSRF via unsupported schemes like `file://` or `ftp://`.
+**Learning:** Even internal queue processors should distrust inputs hydrated from the database/storage, as they might have bypassed frontend validation or been manually inserted.
+**Prevention:** Always parse dynamic URLs using `new URL()` and explicitly enforce `http:` or `https:` protocols before using them in server-side `fetch()` requests.

--- a/src/mq/MQCallback.ts
+++ b/src/mq/MQCallback.ts
@@ -19,6 +19,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const callbackUrl = new URL(asyncContent.callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersCallback) {
 			for (let [key, value] of Object.entries(asyncContent.headersCallback)) {

--- a/src/mq/MQDestiny.ts
+++ b/src/mq/MQDestiny.ts
@@ -19,6 +19,23 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const destinyUrl = new URL(asyncContent.destiny);
+		if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+			await MQStore(rawmsg, env, {
+				type: 'error',
+				resettime: true
+			});
+			return;
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersDestiny) {
 			for (let [key, value] of Object.entries(asyncContent.headersDestiny)) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF). The queue processors (`MQDestiny.ts` and `MQCallback.ts`) were consuming destination and callback URLs originating from database/R2 state without validating the protocol schema before passing them to the server-side `fetch()` API.
🎯 **Impact:** Maliciously crafted messages in the queue (or bypassed frontend validations) could trick the backend worker into making requests to unauthorized internal systems, using dangerous schemes like `file://` or `ftp://`, or creating endless retry loops for invalid URLs.
🔧 **Fix:** Utilized the native V8 `new URL()` to parse and validate the URLs. Explicitly enforced that the URL protocol must be exactly `http:` or `https:`. Invalid URLs or unsupported protocols will be caught securely and marked with an `error` state in `MQStore` to avoid retry loops without executing the fetch.
✅ **Verification:** Ran `pnpm test` successfully. Tests for the MQ processors and panel paths successfully pass with no regressions.

---
*PR created automatically by Jules for task [4238088066636652976](https://jules.google.com/task/4238088066636652976) started by @frkr*