### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in worker outbound fetches

### DIFF
--- a/src/mq/MQCallback.ts
+++ b/src/mq/MQCallback.ts
@@ -19,6 +19,19 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const callbackUrl = new URL(asyncContent.callback);
+		if (callbackUrl.protocol !== 'http:' && callbackUrl.protocol !== 'https:') {
+			throw new Error('Invalid callback URL protocol');
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersCallback) {
 			for (let [key, value] of Object.entries(asyncContent.headersCallback)) {

--- a/src/mq/MQDestiny.ts
+++ b/src/mq/MQDestiny.ts
@@ -19,6 +19,19 @@ export default async function(rawmsg: Message<unknown>, env: Env) {
 	}
 	
 	try {
+		const destinyUrl = new URL(asyncContent.destiny);
+		if (destinyUrl.protocol !== 'http:' && destinyUrl.protocol !== 'https:') {
+			throw new Error('Invalid destiny URL protocol');
+		}
+	} catch (e) {
+		await MQStore(rawmsg, env, {
+			type: 'error',
+			resettime: true
+		});
+		return;
+	}
+
+	try {
 		let headers = new Headers();
 		if (asyncContent.headersDestiny) {
 			for (let [key, value] of Object.entries(asyncContent.headersDestiny)) {


### PR DESCRIPTION
This PR addresses a Server-Side Request Forgery (SSRF) vulnerability.

In `MQDestiny.ts` and `MQCallback.ts`, dynamic destinations and callback URLs were fetched without strictly asserting the URL scheme. An attacker could have abused this to trigger fetches against local protocols (like `file://`) depending on the execution context. 

The fix explicitly uses `new URL()` to both assert valid URL structure and verify that the `protocol` strictly matches either `http:` or `https:` prior to dispatching `fetch`. Invalid combinations result in the message being safely marked as an `error`.

---
*PR created automatically by Jules for task [8582038654550307091](https://jules.google.com/task/8582038654550307091) started by @frkr*